### PR TITLE
[Fix]

### DIFF
--- a/lib/Dwoo/Compiler.php
+++ b/lib/Dwoo/Compiler.php
@@ -955,7 +955,7 @@ class Compiler implements ICompiler
             echo '=============================================================================================' . "\n";
         }
 
-        $this->template = $this->dwoo = null;
+        $this->template = null;
         $tpl = null;
 
         return $output;


### PR DESCRIPTION
 - deleted dwoo property, creation of dynamic property  is deprecated (php 8)