### PR TITLE
Plugin.php fix PHP8.5 deprecation notice

### DIFF
--- a/lib/Dwoo/Compiler.php
+++ b/lib/Dwoo/Compiler.php
@@ -955,7 +955,7 @@ class Compiler implements ICompiler
             echo '=============================================================================================' . "\n";
         }
 
-        $this->template = $this->dwoo = null;
+        $this->template = null;
         $tpl = null;
 
         return $output;

--- a/lib/Dwoo/Plugins/Filters/PluginHtmlFormat.php
+++ b/lib/Dwoo/Plugins/Filters/PluginHtmlFormat.php
@@ -76,8 +76,8 @@ class PluginHtmlFormat extends Filter
      */
     protected static function tagDispatcher($input)
     {
-        // textarea, pre, code tags and comments are to be left alone to avoid any non-wanted whitespace inside them so it just outputs them as they were
-        if (substr($input[1], 0, 9) == '<textarea' || substr($input[1], 0, 4) == '<pre' || substr($input[1], 0, 5) == '<code' || substr($input[1], 0, 4) == '<!--' || substr($input[1], 0, 9) == '<![CDATA[') {
+        // textarea, pre, and code tags are to be left alone to avoid any non-wanted whitespace inside them so it just outputs them as they were
+        if (substr($input[1], 0, 9) == '<textarea' || substr($input[1], 0, 4) == '<pre' || substr($input[1], 0, 5) == '<code' || substr($input[1], 0, 9) == '<![CDATA[') {
             return $input[1] . $input[3];
         }
         // closing textarea, code and pre tags and self-closed tags (i.e. <br />) are printed as singleTags because we didn't use openTag for the formers and the latter is a single tag

--- a/lib/Dwoo/Plugins/Functions/PluginReplace.php
+++ b/lib/Dwoo/Plugins/Functions/PluginReplace.php
@@ -44,9 +44,9 @@ class PluginReplace extends Plugin implements ICompilable
     public static function compile(Compiler $compiler, $value, $search, $replace, $case_sensitive = true)
     {
         if ($case_sensitive == 'false' || (bool)$case_sensitive === false) {
-            return 'str_ireplace(' . $search . ', ' . $replace . ', ' . $value . ')';
+            return 'str_ireplace(' . $search . ', ' . $replace . ', ' . $value . ' ?? \'\')';
         } else {
-            return 'str_replace(' . $search . ', ' . $replace . ', ' . $value . ')';
+            return 'str_replace(' . $search . ', ' . $replace . ', ' . $value . ' ?? \'\')';
         }
     }
 }


### PR DESCRIPTION
Dwoo\Plugin::paramsToAttributes(): Implicitly marking parameter $compiler as nullable is deprecated, the explicit nullable type must be used instead